### PR TITLE
Fix dangling buffer object reference for async_send operations

### DIFF
--- a/azmq/detail/send_op.hpp
+++ b/azmq/detail/send_op.hpp
@@ -43,7 +43,7 @@ public:
     }
 
 private:
-    ConstBufferSequence const& buffers_;
+    ConstBufferSequence buffers_;
     flags_type flags_;
 };
 


### PR DESCRIPTION
The send_buffer_op_base object only saved a reference to the
boost::asio::const_buffer object given to async_send(). This required
callers to ensure the same life-time for the boost::asio::const_buffer
as for the underlying memory it refers to, because destroying the
boost::asio::const_buffer would lead to a dangling reference in the
socket_service's operations queue.

This seems to be an unnecessarily strict requirement. boost::asio normally
only requires callers to ensure the underlying memory stays valid until
the operation's completion handler is called, and will make copies of the
boost::asio::const_buffer/boost::asio::mutable_buffer as needed.
(see for example boost::asio's reactive_socket_send_op_base)
Even azmq's receive_buffer_op_base already saves a copy of the given
MutableBufferSequence.

Thus it seems better to let async_send operations make a copy too, for
consistency.

This fixes #145 (https://github.com/zeromq/azmq/issues/145).